### PR TITLE
Fixed the migration creator

### DIFF
--- a/lib/nifty/key_value_store/migration_generator.rb
+++ b/lib/nifty/key_value_store/migration_generator.rb
@@ -13,7 +13,7 @@ module Nifty
       end
       
       def create_model_file
-        migration_template 'migration.rb', "db/migrate/create_nifty_key_value_store_table"
+        migration_template 'migration.rb', "db/migrate/create_nifty_key_value_store_table.rb"
       end
       
     end


### PR DESCRIPTION
The `create_model_file` method created a migration file but didn't add the `.rb` extension to the end.
